### PR TITLE
ADDON-20240: Add code coverage to HEC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
+group :test do
+  gem 'simplecov', require: false
+end
+
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in fluent-plugin-splunk_hec_output.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-splunk-hec (1.0.0)
+    fluent-plugin-splunk-hec (1.0.1)
       fluentd (~> 1.0)
       multi_json (~> 1.13)
       net-http-persistent (~> 3.0)
@@ -11,12 +11,13 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    connection_pool (2.2.1)
+    connection_pool (2.2.2)
     cool.io (1.5.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     dig_rb (1.0.1)
-    fluentd (1.1.0)
+    docile (1.3.1)
+    fluentd (1.3.0)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -29,31 +30,37 @@ GEM
       yajl-ruby (~> 1.0)
     hashdiff (0.3.7)
     http_parser.rb (0.6.0)
+    json (2.1.0)
     minitest (5.11.3)
-    msgpack (1.2.2)
+    msgpack (1.2.4)
     multi_json (1.13.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
     power_assert (1.1.1)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rake (10.5.0)
     safe_yaml (1.0.4)
-    serverengine (2.0.6)
+    serverengine (2.0.7)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     strptime (0.2.3)
     test-unit (3.2.7)
       power_assert
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.3)
+    tzinfo-data (1.2018.7)
       tzinfo (>= 1.0.0)
-    webmock (3.3.0)
+    webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.1)
 
 PLATFORMS
   ruby
@@ -63,8 +70,9 @@ DEPENDENCIES
   fluent-plugin-splunk-hec!
   minitest (~> 5.0)
   rake (~> 10.0)
+  simplecov
   test-unit (~> 3.0)
-  webmock (~> 3.2)
+  webmock (~> 3.4.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+  t.verbose = false
+  t.warning = false
 end
 
 task :default => :test

--- a/fluent-plugin-splunk-hec.gemspec
+++ b/fluent-plugin-splunk-hec.gemspec
@@ -37,5 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit", "~> 3.0" # required by fluent/test.rb
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "webmock", "~> 3.2"
+  spec.add_development_dependency "webmock", "~> 3.4.2"
+  spec.add_development_dependency "simplecov", "~> 0.16.1"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "fluent/plugin/out_splunk_hec"


### PR DESCRIPTION
run with `rake`

Note: setting rake file `t.verbose` and `t.warning` to true results in:
 `warning: instance variable @metric_value not initialized`