### PR TITLE
Format nested fields using dot-notation

### DIFF
--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -233,7 +233,7 @@ module Fluent::Plugin
 
     # Format hash using dot-notation
     def dot_it(object, prefix = nil)
-      if object.is_a? Hash
+      if (object.is_a? Hash) && (!object.keys.count.zero?)
         object.map do |key, value|
           if prefix
             dot_it value, "#{prefix}.#{key}"
@@ -265,6 +265,7 @@ module Fluent::Plugin
 	if @extra_fields
 	  payload[:fields] = dot_it @extra_fields.map { |name, field| [name, record[field]] }.to_h
 	  payload[:fields].compact!
+	  payload[:fields].delete_if { |k, v| !(v.is_a? Integer) && v.empty? }
 	  # if a field is already in indexed fields, then remove it from the original event
 	  @extra_fields.values.each { |field| record.delete field }
 	end

--- a/test/fluent/plugin/out_splunk_hec_test.rb
+++ b/test/fluent/plugin/out_splunk_hec_test.rb
@@ -145,6 +145,7 @@ describe Fluent::Plugin::SplunkHecOutput do
       from
       logLevel level
       nonexist
+      agent
     </fields>
     CONF
       batch.each do |item|
@@ -156,6 +157,8 @@ describe Fluent::Plugin::SplunkHecOutput do
 	expect(item['fields']['from']).must_equal 'my_machine'
 	expect(item['fields']['logLevel']).must_equal 'info'
 	expect(item['fields']).wont_be :has_key?, 'nonexist'
+	expect(item['fields']['agent.name']).must_equal 'test'
+	expect(item['fields']['agent.version']).must_equal '1.0.0'
       end
     }
   end


### PR DESCRIPTION
Added support for sending nested data as fields using dot-notation.
We use this with the kubernetes_metadata plugin to send all kubernetes pod labels as fields.
dot_it function copied from https://stackoverflow.com/questions/17451487/classic-hash-to-dot-notation-hash