### PR TITLE
Teach the output plugin about a new Auth host

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [Fluentd](https://fluentd.org/) output plugin to send events and metrics to [Splunk](https://www.splunk.com) in 2 modes:<br/>
 1) Via Splunk's [HEC (HTTP Event Collector) API](http://dev.splunk.com/view/event-collector/SP-CAAAE7F)<br/> 
-2) Via the [Splunk Ingest API](https://sdc.splunkbeta.com/reference/api/ingest/v1beta2)
+2) Via the Splunk Cloud Services (SCS) [Ingest API](https://sdc.splunkbeta.com/reference/api/ingest/v1beta2)
 
 ## Installation
 
@@ -29,7 +29,7 @@ $ bundle
 
 * See also: [Output Plugin Overview](https://docs.fluentd.org/v1.0/articles/output-plugin-overview)
 
-#### Example 1: Minimum Configuration
+#### Example 1: Minimum HEC Configuration
 
 ```
 <match **>
@@ -43,17 +43,18 @@ $ bundle
 This example is very basic, it just tells the plugin to send events to Splunk HEC on `https://12.34.56.78:8088` (https is the default protocol), using the HEC token `00000000-0000-0000-0000-000000000000`. It will use whatever index, source, sourcetype are configured in HEC. And the `host` of each event is the hostname of the machine which running fluentd.
 
 
-#### Example 2: Configuration example
+#### Example 2: SCS Ingest Configuration example
 
 ```
 <match **>
 @type splunk_ingest_api
 service_client_identifier xxxxxxxx
 service_client_secret_key xxxx-xxxxx
-token_endpoint /system/identity/v2beta1/token
-ingest_api_host api.url.splunk.com
-ingest_api_tenant mytenant
-ingest_api_events_endpoint /ingest/mybuild/events
+token_endpoint /token
+ingest_auth_host auth.scp.splunk.com
+ingest_api_host api.scp.splunk.com
+ingest_api_tenant <mytenant>
+ingest_api_events_endpoint /<mytenant>/ingest/v1beta2/events
 debug_http false
 </match>
 ```

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fluent/env'
 require 'fluent/output'
 require 'fluent/plugin/output'
 require 'fluent/plugin/formatter'

--- a/lib/fluent/plugin/out_splunk_ingest_api.rb
+++ b/lib/fluent/plugin/out_splunk_ingest_api.rb
@@ -16,10 +16,13 @@ module Fluent::Plugin
     config_param :service_client_secret_key, :string, default: nil
 
     desc 'Token Endpoint'
-    config_param :token_endpoint, :string, default: '/system/identity/v1/token'
+    config_param :token_endpoint, :string, default: '/token'
+
+    desc 'Token Auth Hostname'
+    config_param :ingest_auth_host, :string, default: 'auth.scp.splunk.com'
 
     desc 'Ingest Api Hostname'
-    config_param :ingest_api_host, :string, default: 'api.splunkbeta.com'
+    config_param :ingest_api_host, :string, default: 'api.scp.splunk.com'
 
     desc 'Ingest API Tenant Name'
     config_param :ingest_api_tenant, :string
@@ -90,7 +93,7 @@ module Fluent::Plugin
         identifier: @service_client_identifier,
         secret: @service_client_secret_key,
         redirect_uri: 'http://localhost:8080/', # Not used
-        host: @ingest_api_host,
+        host: @ingest_auth_host,
         scheme: 'https'
       )
 

--- a/test/fluent/plugin/out_splunk_ingest_api_test.rb
+++ b/test/fluent/plugin/out_splunk_ingest_api_test.rb
@@ -6,8 +6,8 @@ describe Fluent::Plugin::SplunkIngestApiOutput do
   include Fluent::Test::Helpers
   include PluginTestHelper
 
-  INGEST_API_ENDPOINT = 'https://api.splunkbeta.com/tenant_name/ingest/v1beta2/events'
-  AUTH_TOKEN_ENDPOINT = 'https://api.splunkbeta.com/system/identity/v1/token'
+  INGEST_API_ENDPOINT = 'https://api.scp.splunk.com/tenant_name/ingest/v1beta2/events'
+  AUTH_TOKEN_ENDPOINT = 'https://auth.scp.splunk.com/token'
 
   before { Fluent::Test.setup } # setup router and others
 


### PR DESCRIPTION
The auth endpoint is moving and there is a new auth host, separate from the api host.
The default auth host is auth.scp.splunk.com
The default auth endpoint is /token

## Proposed changes

SCS recently made 2 changes.
1. Moved the token endpoint
2. added a new auth hosts

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

