### PR TITLE
Update SSL parameter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ List of SSl ciphers allowed.
 
 #### insecure_ssl (bool)
 
-Specifies whether an insecure SSL connection is allowed. If set to false, Splunk does not verify an insecure server certificate. This parameter is set to `false` by default.
+Specifies whether an insecure SSL connection is allowed. If set to false, Splunk does not verify an insecure server certificate. This parameter is set to `false` by default. Ensure other SSL parameters (e.g. ca_path, ca_file) are not configured in order to allow insecure SSL connections.
 
 ## About Buffer
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ List of SSl ciphers allowed.
 
 #### insecure_ssl (bool)
 
-Specifies whether an insecure SSL connection is allowed. If set to false, Splunk does not verify an insecure server certificate. This parameter is set to `false` by default. Ensure other SSL parameters (e.g. ca_path, ca_file) are not configured in order to allow insecure SSL connections.
+Specifies whether an insecure SSL connection is allowed. If set to false, Splunk does not verify an insecure server certificate. This parameter is set to `false` by default. Ensure parameter `ca_file` is not configured in order to allow insecure SSL connections when this value is set to `true`.
 
 ## About Buffer
 


### PR DESCRIPTION
## Proposed changes

Update SSL parameter documentation to indicate `ca_file` forces HTTP verify_mode to `VERIFY_PEER` despite `insecure_ssl true` being set as described by #99 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [X] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

