### PR TITLE
Update min version of net-http-persistent to 3.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES
   fluentd (~> 1.9.0)
   minitest (~> 5.0)
   multi_json (~> 1.13)
-  net-http-persistent (~> 3.0)
+  net-http-persistent (~> 3.1)
   openid_connect (~> 1.1.8)
   prometheus-client (< 0.10.0)
   rake (~> 12.0)

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-# This is separate gemfile for building docker image that has all plugins 
+# This is separate gemfile for building docker image that has all plugins
 # for kubernetes log collection agent
 # List all required gems here and install via bundler to resolve dependencies
-gem "fluentd", "=1.9.1" 
+gem "fluentd", "=1.9.1"
 gem "fluent-plugin-systemd", "=1.0.2"
 gem "fluent-plugin-concat", "=2.4.0"
 gem "fluent-plugin-prometheus", "=1.7.0"
@@ -11,7 +11,7 @@ gem "fluent-plugin-jq", "=0.5.1"
 gem "fluent-plugin-kubernetes_metadata_filter", "=2.4.2"
 gem "oj", "=3.10.2"
 gem 'multi_json', '~> 1.13'
-gem 'net-http-persistent', '~> 3.0'
+gem 'net-http-persistent', '~> 3.1'
 gem 'openid_connect', '~> 1.1.8'
 gem 'prometheus-client', '< 0.10.0'
 gem 'activesupport', '~> 5.2'

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -153,7 +153,7 @@ DEPENDENCIES
   fluent-plugin-systemd (= 1.0.2)
   fluentd (= 1.9.1)
   multi_json (~> 1.13)
-  net-http-persistent (~> 3.0)
+  net-http-persistent (~> 3.1)
   oj (= 3.10.2)
   openid_connect (~> 1.1.8)
   prometheus-client (< 0.10.0)

--- a/fluent-plugin-splunk-hec.gemspec
+++ b/fluent-plugin-splunk-hec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fluent-plugin-kubernetes_metadata_filter', '~> 2.4.2'
   spec.add_runtime_dependency 'fluentd', '~> 1.9.0'
   spec.add_runtime_dependency 'multi_json', '~> 1.13'
-  spec.add_runtime_dependency 'net-http-persistent', '~> 3.0'
+  spec.add_runtime_dependency 'net-http-persistent', '~> 3.1'
   spec.add_runtime_dependency 'openid_connect', '~> 1.1.8'
   spec.add_runtime_dependency 'prometheus-client', '< 0.10.0'
   spec.add_runtime_dependency 'activesupport', '~> 5.2'


### PR DESCRIPTION
## Proposed changes

Bump min version of net-http-persistent to avoid issue when running on windows. See https://github.com/drbrain/net-http-persistent/pull/90 and https://github.com/splunk/fluent-plugin-splunk-hec/pull/64

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

