### PR TITLE
Allow users to specify a key for extra fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ and the following input event:
 
 Then, a metric of "CPU Usage" with value=100, along with 3 dimensions file="server.rb", status="OK", and app="webServer" are sent to Splunk.
 
+### fields_key (string) (optional)
+
+Lets you specify the key for a hash of additional key value pairs to add as index-time fields for an event. The fields in the hash specified by `fields_key` will be merged with any fields in the `<fields>` section, with values in `fields_key` winning in the case of conflict.
+
 ### &lt;format&gt; section (optional) (multiple)
 
 The `<format>` section let you define which formatter to use to format events.


### PR DESCRIPTION
## Proposed changes

Sometimes it is desired to be able to add fields to the HEC payload
without knowing fluentd having to statically know their names in the
<fields> section, such as using annotations to define extra index time
fields. By providing an optional fields_key parameter, users can write
custom filters to add keys to a hash on the record that will then be
added as fields on the payload.

The first commit is a refactor to allow both `out_splunk_hec.rb` and `out_splunk_ingest_api.rb` to share the code in `prepare_event_payload`. The second commit adds the new feature.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

