### PR TITLE
Add option to fail buffer flushing on 4xx errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,10 @@ List of SSl ciphers allowed.
 
 Specifies whether an insecure SSL connection is allowed. If set to false, Splunk does not verify an insecure server certificate. This parameter is set to `false` by default. Ensure parameter `ca_file` is not configured in order to allow insecure SSL connections when this value is set to `true`.
 
+#### consume_chunk_on_4xx_errors (bool)
+
+Specifies whether any 4xx HTTP response status code consumes the buffer chunks. If set to false, Splunk will fail to flush the buffer on such status codes. This parameter is set to `true` by default for backwards compatibility.
+
 ## About Buffer
 
 This plugin sends events to HEC using [batch mode](https://docs.splunk.com/Documentation/Splunk/7.1.0/Data/FormateventsforHTTPEventCollector#Event_data).

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -97,7 +97,10 @@ module Fluent::Plugin
     config_section :fields, init: false, multi: false, required: false do
       # this is blank on purpose
     end
-    
+
+    desc 'Indicates if 4xx errors should consume chunk'
+    config_param :consume_chunk_on_4xx_errors, :bool, :default => true
+
     config_section :format do
       config_set_default :usage, '**'
       config_set_default :@type, 'json'
@@ -302,11 +305,12 @@ module Fluent::Plugin
       response = @conn.request @api, post
       t2 = Time.now
 
-      # raise Exception to utilize Fluentd output plugin retry machanism
-      raise "Server error (#{response.code}) for POST #{@api}, response: #{response.body}" if response.code.start_with?('5')
+      raise_err = response.code.to_s.start_with?('5') || (!@consume_chunk_on_4xx_errors && response.code.to_s.start_with?('4'))
 
-      # For both success response (2xx) and client errors (4xx), we will consume the chunk.
-      # Because there probably a bug in the code if we get 4xx errors, retry won't do any good.
+      # raise Exception to utilize Fluentd output plugin retry mechanism
+      raise "Server error (#{response.code}) for POST #{@api}, response: #{response.body}" if raise_err
+
+      # For both success response (2xx) we will consume the chunk.
       if not response.code.start_with?('2')
         log.error "Failed POST to #{@api}, response: #{response.body}"
         log.debug { "Failed request body: #{post.body}" }

--- a/test/fluent/plugin/out_splunk_hec_test.rb
+++ b/test/fluent/plugin/out_splunk_hec_test.rb
@@ -57,6 +57,9 @@ describe Fluent::Plugin::SplunkHecOutput do
       assert_nil(create_hec_output_driver('hec_host hec_token').instance.index_key)
       expect(create_hec_output_driver('hec_host hec_token').instance.index_key).is_a? String
     end
+    it 'should consume chunks on 4xx errors' do
+      expect(create_hec_output_driver('hec_host hec_token').instance.consume_chunk_on_4xx_errors).must_equal true
+    end
   end
 
   describe 'hec_host validation' do


### PR DESCRIPTION
## Proposed changes
Related to: https://github.com/splunk/fluent-plugin-splunk-hec/issues/153

## Types of changes
Adds an option to fail the buffer flushing on 4xx errors

What types of changes does your code introduce?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

