### PR TITLE
Add time key to key_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ Cannot set both `source` and `source_key` parameters at the same time.
 
 Field name that contains the sourcetype. Cannot set both `source` and `source_key` parameters at the same time.
 
+### time_key (string) (optional)
+
+Field name to contain Splunk event time. By default will use fluentd\'d time.
+
 ### fields (init) (optional)
 
 Lets you specify the index-time fields for the event data type, or metric dimensions for the metric data type. Null value fields are removed.

--- a/lib/fluent/plugin/out_splunk.rb
+++ b/lib/fluent/plugin/out_splunk.rb
@@ -13,7 +13,7 @@ module Fluent::Plugin
     autoload :VERSION, 'fluent/plugin/out_splunk/version'
     autoload :MatchFormatter, 'fluent/plugin/out_splunk/match_formatter'
 
-    KEY_FIELDS = %w[index host source sourcetype metric_name metric_value].freeze
+    KEY_FIELDS = %w[index host source sourcetype metric_name metric_value time].freeze
     TAG_PLACEHOLDER = '${tag}'
 
     desc 'The host field for events, by default it uses the hostname of the machine that runnning fluentd. This is exclusive with `host_key`.'

--- a/test/fluent/plugin/out_splunk_hec_test.rb
+++ b/test/fluent/plugin/out_splunk_hec_test.rb
@@ -139,6 +139,7 @@ describe Fluent::Plugin::SplunkHecOutput do
       host_key       from
       source_key     file
       sourcetype_key agent.name
+      time_key       timestamp
     CONF
       batch.each do |item|
         expect(item['index']).must_equal 'info'
@@ -147,7 +148,7 @@ describe Fluent::Plugin::SplunkHecOutput do
         expect(item['sourcetype']).must_equal 'test'
 
         JSON.load(item['event']).tap do |event|
-          %w[level from file].each { |field| expect(event).wont_include field }
+          %w[level from file timestamp].each { |field| expect(event).wont_include field }
           expect(event['agent']).wont_include 'name'
         end
       end
@@ -349,7 +350,8 @@ describe Fluent::Plugin::SplunkHecOutput do
       'agent' => {
         'name' => 'test',
         'version' => '1.0.0'
-      }
+      },
+      'timestamp' => 'time'
     }
     events = [
       ['tag.event1', event_time, { 'id' => '1st' }.merge(Marshal.load(Marshal.dump(event)))],


### PR DESCRIPTION
## Proposed changes

I noticed that the time_key was not part of the `KEY_FIELDS` array that's used to remove keys from the event. I added it and also updated the README.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

