### PR TITLE
Dont post all whitespace events to HEC

### DIFF
--- a/test/fluent/plugin/out_splunk_hec_test.rb
+++ b/test/fluent/plugin/out_splunk_hec_test.rb
@@ -220,6 +220,23 @@ describe Fluent::Plugin::SplunkHecOutput do
     end
   end
 
+  it 'should not send blank events' do
+    verify_sent_events(<<~CONF) do |batch|
+      <fields>
+        from
+        logLevel level
+        nonexist
+        log
+        file
+        value
+        id
+        agent
+      </fields>
+    CONF
+      expect(batch.length).must_equal 0
+    end
+  end
+
   describe 'metric' do
     it 'should check related configs' do
       expect(


### PR DESCRIPTION

## Proposed changes
after formatting indexed fields all whitespace events posted result in
  a invalid_raw_is_all_whitespace error
 Save the trouble and just drop the event

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

