### PR TITLE
Workaround false warning: parameter 'x' in <fields> is not used.

### DIFF
--- a/lib/fluent/plugin/out_splunk.rb
+++ b/lib/fluent/plugin/out_splunk.rb
@@ -209,7 +209,7 @@ module Fluent::Plugin
       # This loop looks dump, but it is used to suppress the unused parameter configuration warning
       # Learned from `filter_record_transformer`.
       conf.elements.select { |element| element.name == 'fields' }.each do |element|
-        element.each_pair { |k, _v| element.key?(k) }
+        element.each_pair { |k, _v| element.has_key?(k) }
       end
 
       return unless @fields


### PR DESCRIPTION

## Proposed changes

Currently when starting the pod false warnings are printed about unused fields configuration. The code contains some workaround based on something that is used in the record_transformer filter. But the record_transformer uses the `has_key()` method, not the `key()` method.

Closes  #161 (hopefully, not tested yet) :-) )


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

