### PR TITLE
add `secret: true` to hec_token config_param such that it is redacted…

### DIFF
--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -40,7 +40,7 @@ module Fluent::Plugin
     config_param :full_url, :string, default: ''
 
     desc 'The HEC token.'
-    config_param :hec_token, :string
+    config_param :hec_token, :string, secret: true
 
     desc 'If a connection has not been used for this number of seconds it will automatically be reset upon the next use to avoid attempting to send to a closed connection. nil means no timeout.'
     config_param :idle_timeout, :integer, default: 5


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

## Proposed changes

Set `secret` parameter to `true` for the `hec_token` config_param. This will mask the output within the output of the configuration. The relevant fluentd code: https://github.com/fluent/fluentd/blob/5844f7209fec154a4e6807eb1bee6989d3f3297f/lib/fluent/config/element.rb#L160-L183

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

I didn't add a test because I didn't see a fitting way to add one. If you do, you can find an example in fluentd's core lib:https://github.com/fluent/fluentd/blob/5844f7209fec154a4e6807eb1bee6989d3f3297f/test/config/test_element.rb#L290
