### PR TITLE
Fixed issue where Connection Refused Log error printed incorrect port number

### DIFF
--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -323,10 +323,13 @@ module Fluent::Plugin
       post.body = chunk.read
       log.debug { "[Sending] Chunk: #{dump_unique_id_hex(chunk.unique_id)}(#{post.body.bytesize}B)." }
       log.trace { "POST #{@api} body=#{post.body}" }
-
-      t1 = Time.now
-      response = @conn.request @api, post
-      t2 = Time.now
+      begin
+        t1 = Time.now
+        response = @conn.request @api, post
+        t2 = Time.now
+      rescue Net::HTTP::Persistent::Error => e
+        raise e.cause
+      end
 
       raise_err = response.code.to_s.start_with?('5') || (!@consume_chunk_on_4xx_errors && response.code.to_s.start_with?('4'))
 


### PR DESCRIPTION
Fixed https://github.com/splunk/splunk-connect-for-kubernetes/issues/371 and https://github.com/splunk/fluent-plugin-splunk-hec/issues/184

Exception message was changed in between stack trace and at some point it was replaced with proxy_port which defaults to 80. So raised cause of exception `Net::HTTP::Persistent::Error` is raised. 

Now, the following error will be logged:
```
2021-12-09 08:59:16 +0000 [error]: #0 failed to flush the buffer, and hit limit for retries. dropping all chunks in the buffer queue. retry_times=5 records=29841 error_class=Errno::ECONNREFUSED error="Failed to open TCP connection to 10.202.9.155:12088 (Connection refused - connect(2) for \"xx.xx.xx.xx" port yyyy)"
```