### PR TITLE
enabled tag interpolation for source value

### DIFF
--- a/lib/fluent/plugin/out_splunk.rb
+++ b/lib/fluent/plugin/out_splunk.rb
@@ -193,8 +193,8 @@ module Fluent::Plugin
           v = instance_variable_get "@#{f}"
           next unless v
 
-          if v == TAG_PLACEHOLDER
-            instance_variable_set "@#{f}", ->(tag, _) { tag }
+          if v.include? TAG_PLACEHOLDER
+            instance_variable_set "@#{f}", ->(tag, _) { v.gsub(TAG_PLACEHOLDER, tag) }
           else
             instance_variable_set "@#{f}", ->(_, _) { v }
           end


### PR DESCRIPTION
Fixing https://github.com/splunk/fluent-plugin-splunk-hec/issues/90

User can set source value to `blah/app/thing/{tag}` and `${tag} will be replaced with actual tag