### PR TITLE
Support optional GZIP compression on outbound posts to splunk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'simplecov', require: false
+  gem 'net-smtp', require: false
 end
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     cool.io (1.7.1)
     crack (0.4.5)
       rexml
+    digest (3.1.0)
     docile (1.4.0)
     fluentd (1.14.6)
       bundler
@@ -46,6 +47,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    io-wait (0.2.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -58,6 +60,13 @@ GEM
     multi_json (1.15.0)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     openid_connect (1.1.8)
       activemodel
       attr_required (>= 1.0.0)
@@ -96,6 +105,7 @@ GEM
       httpclient (>= 2.4)
     test-unit (3.5.3)
       power_assert
+    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.1)
@@ -123,6 +133,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   fluent-plugin-splunk-hec!
   minitest (~> 5.0)
+  net-smtp
   rake (>= 12.0)
   simplecov
   test-unit (~> 3.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,4 +42,15 @@ module PluginTestHelper
                        'User-Agent' => "fluent-plugin-splunk_hec_out/#{Fluent::Plugin::SplunkHecOutput::VERSION}" })
       .to_return(body: '{"text":"Success","code":0}')
   end
+
+  def stub_hec_gzip_request(endpoint)
+    stub_request(:post, "#{endpoint}/services/collector")
+      .with(headers: {
+        'Authorization' => "Splunk #{TEST_HEC_TOKEN}",
+        'User-Agent' => "fluent-plugin-splunk_hec_out/#{Fluent::Plugin::SplunkHecOutput::VERSION}",
+        'Content-Encoding' => "gzip"
+      },
+      )
+      .to_return(body: '{"text":"GzipSuccess","code":0}')
+  end
 end


### PR DESCRIPTION
## Proposed changes

Hoping gzip compression here will help reduce our internet bandwidth consumption leveraging splunk hec to push events to splunk cloud.

Fixes https://github.com/splunk/fluent-plugin-splunk-hec/issues/14

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


