### PR TITLE
Add custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ Splunk app name using this plugin (default to `hec_plugin_gem`)
 
 The version of Splunk app using this this plugin (default to plugin version)
 
+### custom_headers (Hash) (Optional)
+
+Hash of custom headers to be added to the HTTP request. Used to populate [`override_headers`](https://docs.seattlerb.org/net-http-persistent/Net/HTTP/Persistent.html#attribute-i-override_headers) attribute of the underlying `Net::HTTP::Persistent` connection.
+
 #### When `data_type` is `event`
 
 In this case, parameters inside `<fields>` are used as indexed fields and removed from the original input events. Please see the "Add a "fields" property at the top JSON level" [here](http://dev.splunk.com/view/event-collector/SP-CAAAFB6) for details. Given we have configuration like

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -171,7 +171,7 @@ module Fluent::Plugin
         c.override_headers['Authorization'] = "Splunk #{@hec_token}"
         c.override_headers['__splunk_app_name'] = "#{@app_name}"
         c.override_headers['__splunk_app_version'] = "#{@app_version}"
-        @custom_headers.each |header, value| do
+        @custom_headers.each do |header, value|
           c.override_headers[header] = value
         end
       end

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -134,6 +134,9 @@ module Fluent::Plugin
     DESC
     config_param :non_utf8_replacement_string, :string, :default => ' '
 
+    desc 'Any custom headers to include alongside requests made to Splunk'
+    config_param :custom_headers, :hash, :default => {}
+    
     def initialize
       super
       @default_host = Socket.gethostname
@@ -168,7 +171,9 @@ module Fluent::Plugin
         c.override_headers['Authorization'] = "Splunk #{@hec_token}"
         c.override_headers['__splunk_app_name'] = "#{@app_name}"
         c.override_headers['__splunk_app_version'] = "#{@app_version}"
-
+        @custom_headers.each |header, value| do
+          c.override_headers[header] = value
+        end
       end
     end
 

--- a/test/fluent/plugin/out_splunk_hec_test.rb
+++ b/test/fluent/plugin/out_splunk_hec_test.rb
@@ -71,8 +71,7 @@ describe Fluent::Plugin::SplunkHecOutput do
       expect(create_hec_output_driver('hec_host hec_token').instance.custom_headers).is_a? Hash
     end
     it 'should allow setting custom_headers' do
-      assert_empty(create_hec_output_driver('hec_host hec_token', 'custom_headers {"custom":"header"}').instance.custom_headers)
-      expect(create_hec_output_driver('hec_host hec_token').instance.custom_headers).must_equal {"custom":"header"}
+      assert_equal(create_hec_output_driver('hec_host hec_token', 'custom_headers {"custom":"header"}').instance.custom_headers, {"custom" => "header"})
     end
   end
 

--- a/test/fluent/plugin/out_splunk_hec_test.rb
+++ b/test/fluent/plugin/out_splunk_hec_test.rb
@@ -66,6 +66,14 @@ describe Fluent::Plugin::SplunkHecOutput do
     it 'should support enabling gzip' do
       expect(create_hec_output_driver('hec_host hec_token', 'gzip_compression true').instance.gzip_compression).must_equal true
     end
+    it 'should define custom_headers as {} (hash) initially' do
+      assert_empty(create_hec_output_driver('hec_host hec_token').instance.custom_headers)
+      expect(create_hec_output_driver('hec_host hec_token').instance.custom_headers).is_a? Hash
+    end
+    it 'should allow setting custom_headers' do
+      assert_empty(create_hec_output_driver('hec_host hec_token', 'custom_headers {"custom":"header"}').instance.custom_headers)
+      expect(create_hec_output_driver('hec_host hec_token').instance.custom_headers).must_equal {"custom":"header"}
+    end
   end
 
   describe 'hec_host validation' do


### PR DESCRIPTION
## Proposed changes

We do something particularly silly, and run a [CloudStrike Falcon LogScale](https://www.crowdstrike.com/products/observability/falcon-logscale/) instance (nee [Humio](https://www.humio.com/)) behind a Kubernetes Ingress on one of our clusters that we'd like to emit logs to via Fluentd from various other Kubernetes clusters. In order to traverse that Ingress, we need to present a custom Authorization header alongside our requests. This PR adds support for a new configuration parameter, `custom_headers`, that is used to populate the `override_headers` Hash used in requests made by this plugin.

For context here, prior to the Elasticsearch 8.0.0 release Humio recommended using Fluentd's `elasticsearch` output plugin for use in relaying logs for ingest, but now recommends use of this [`splunk_hec` output plugin instead](https://library.humio.com/humio-server/log-shippers-fluentd.html). Said `elasticsearch` output plugin supported [a virtually identical `custom_headers` configuration block](https://github.com/uken/fluent-plugin-elasticsearch#custom_headers), which we used for this purpose.

It's been ages since I wrote much Ruby anything, but I've attempted to add relevant tests in-line with the existing tests I see in this repository, and `make unit-test` runs without issue for me - but please let me know if there's something else I should test, or some better way to go around adding this functionality. (I noticed the exposed `proxy_from_env` hook, but wasn't sure if that could be leveraged for this use-case.)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/fluent-plugin-splunk-hec/blob/develop/CLA.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

