### PR TITLE
Update README to include nuance from OTEL collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Important:** The fluent-plugin-splunk-hec will reach End of Support on January 1, 2024. After that date, this repository will no longer receive updates from Splunk and will no longer be supported by Splunk. Until then, only critical security fixes and bug fixes will be provided.
 
+Note that the **Fluentd logs engine** component of Splunk OTEL Collector is also deprecated, and has reached end of support as of October 2025.
+
 # fluent-plugin-splunk-hec
 
 [Fluentd](https://fluentd.org/) output plugin to send events and metrics to [Splunk](https://www.splunk.com) in 2 modes:<br/>


### PR DESCRIPTION
## Description

This adds a small amount of clarity to the Fluentd collector, from what I read:
- Splunk fluentd logs engine ends support this month
- Migrating to the native OTEL logs engine before this date is now a requirement

This wasn't fully captured in the fluent-plugin repo, so adding it here for prosperity

See https://github.com/signalfx/splunk-otel-collector-chart/?tab=readme-ov-file#current-status from where this information is sourced
